### PR TITLE
Ignore sqlserver rowversion fields. Add logging in dbtool

### DIFF
--- a/samples/DbUtilsDemo.AspNetCore/Data/AppDbContext.cs
+++ b/samples/DbUtilsDemo.AspNetCore/Data/AppDbContext.cs
@@ -45,6 +45,14 @@ namespace DbUtilsDemo
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<Customer>()
+                .Property(c => c.RowVersion)
+                .IsRowVersion();
+
+            modelBuilder.Entity<Order>()
+               .Property(o => o.RowVersion)
+               .IsRowVersion();
+
             modelBuilder.Entity<OrderDetail>()
                 .ToTable("Order_Details")
                 .HasKey(od => new { od.OrderID, od.ProductID });

--- a/samples/DbUtilsDemo.AspNetCore/Data/Models/Customer.cs
+++ b/samples/DbUtilsDemo.AspNetCore/Data/Models/Customer.cs
@@ -31,5 +31,8 @@ namespace DbUtilsDemo.Models
 
         public string Fax { get; set; }
 
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
+
     }
 }

--- a/samples/DbUtilsDemo.AspNetCore/Data/Models/Order.cs
+++ b/samples/DbUtilsDemo.AspNetCore/Data/Models/Order.cs
@@ -56,5 +56,8 @@ namespace DbUtilsDemo.Models
         public string ShipPostalCode { get; set; }
 
         public string ShipCountry { get; set; }
+
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
     }
 }

--- a/src/Korzh.DbTool/Commands/ConnectionsCommand.cs
+++ b/src/Korzh.DbTool/Commands/ConnectionsCommand.cs
@@ -8,7 +8,6 @@ namespace Korzh.DbTool
 
     public class ConnectionsCommand : ICommand
     {
-
         public static void Configure(CommandLineApplication command, GlobalOptions options)
         {
             command.Description = "Manipulates with connections (add, remove, list)";
@@ -55,7 +54,7 @@ namespace Korzh.DbTool
                                          .IsRequired();
 
                 DbTypeArg = command.Argument("<database type>", $"The database type ({DbTool.DbType.SqlServer}, {DbTool.DbType.MySql})")
-                   .Accepts(config => config.Values(ignoreCase: true, DbTool.DbType.SqlServer, DbTool.DbType.MySql))
+                   .Accepts(config => config.Values(true, DbTool.DbType.SqlServer, DbTool.DbType.MySql))
                    .IsRequired();
 
                 ConnectionStringArg = command.Argument("<сonnection string>", "The connection string to add")

--- a/src/Korzh.DbTool/Commands/ConnectionsCommand.cs
+++ b/src/Korzh.DbTool/Commands/ConnectionsCommand.cs
@@ -21,7 +21,8 @@ namespace Korzh.DbTool
             command.Command("remove", c => ConnectionsRemoveCommand.Configure(c, options));
             command.Command("list", c => ConnectionsListCommand.Configure(c, options));
 
-            command.OnExecute(new ConnectionsCommand(command).Run);
+            Func<int> runCommandFunc = new ConnectionsCommand(command).Run;
+            command.OnExecute(runCommandFunc);
         }
 
         private CommandLineApplication _command;
@@ -76,7 +77,8 @@ namespace Korzh.DbTool
 
             var argumets = new Arguments(command);
 
-            command.OnExecute(new ConnectionsAddCommand(argumets, options).Run);
+            Func<int> runCommandFunc = new ConnectionsAddCommand(argumets, options).Run;
+            command.OnExecute(runCommandFunc);
         }
 
         private readonly Arguments _arguments;
@@ -118,7 +120,8 @@ namespace Korzh.DbTool
             var connectionIdArg = command.Argument("<сonnection ID>", "The ID of the connection stored in the configuration")
                                         .IsRequired();
 
-            command.OnExecute(new ConnectionsRemoveCommand(connectionIdArg, options).Run);
+            Func<int> runCommandFunc = new ConnectionsRemoveCommand(connectionIdArg, options).Run;
+            command.OnExecute(runCommandFunc);
         }
 
         private readonly CommandArgument _connectionIdArg;
@@ -153,7 +156,8 @@ namespace Korzh.DbTool
 
             command.Options.Add(options.LocalConfigFilePathOption);
 
-            command.OnExecute(new ConnectionsListCommand(options).Run);
+            Func<int> runCommandFunc = new ConnectionsListCommand(options).Run;
+            command.OnExecute(runCommandFunc);
         }
 
         private readonly GlobalOptions _options;

--- a/src/Korzh.DbTool/Commands/ExportCommand.cs
+++ b/src/Korzh.DbTool/Commands/ExportCommand.cs
@@ -104,10 +104,10 @@ namespace Korzh.DbTool
         private IDbReader GetDbReader()
         {
             if (_connection is SqlConnection) {
-                return new SqlServerBridge(_connection as SqlConnection);
+                return new SqlServerBridge(_connection as SqlConnection, Program.LoggerFactory);
             }
             else if (_connection is MySqlConnection){
-                return new MySqlBridge(_connection as MySqlConnection);
+                return new MySqlBridge(_connection as MySqlConnection, Program.LoggerFactory);
             }
 
             return null;
@@ -130,18 +130,18 @@ namespace Korzh.DbTool
                 var zipFilePath = Path.Combine(_arguments.OutputPath, zipFileName ?? _arguments.ConnectionId + "_" 
                                               + DateTime.Now.ToString("yyyy-MM-dd") + ".zip");
 
-                return new ZipFilePacker(zipFilePath);
+                return new ZipFilePacker(zipFilePath, Program.LoggerFactory);
             }
             else if (_arguments.OutputPathOption.HasValue()) {
                 Directory.CreateDirectory(_arguments.OutputPath);
-                return new FileFolderPacker(_arguments.OutputPath);
+                return new FileFolderPacker(_arguments.OutputPath, Program.LoggerFactory);
             }
 
             var directory = _arguments.ConnectionId + "_" + DateTime.Now.ToString("yyyy-MM-dd");
 
             Directory.CreateDirectory(directory);
 
-            return new FileFolderPacker(directory);
+            return new FileFolderPacker(directory, Program.LoggerFactory);
         }
 
         public int Run()

--- a/src/Korzh.DbTool/Commands/ExportCommand.cs
+++ b/src/Korzh.DbTool/Commands/ExportCommand.cs
@@ -57,8 +57,8 @@ namespace Korzh.DbTool
 
             var arguments = new ArgumentsAndOptions(command);
 
-            command.OnExecute(new ExportCommand(arguments, options).Run);
-
+            Func<int> runCommandFunc = new ExportCommand(arguments, options).Run;
+            command.OnExecute(runCommandFunc);
         }
 
         private readonly ArgumentsAndOptions _arguments;

--- a/src/Korzh.DbTool/Commands/ImportCommand.cs
+++ b/src/Korzh.DbTool/Commands/ImportCommand.cs
@@ -115,10 +115,10 @@ namespace Korzh.DbTool
         private IDbWriter GetDbSeeder()
         {
             if (_connection is SqlConnection) {
-                return new SqlServerBridge(_connection as SqlConnection);
+                return new SqlServerBridge(_connection as SqlConnection, Program.LoggerFactory);
             }
             else if (_connection is MySqlConnection) {
-                return new MySqlBridge(_connection as MySqlConnection);
+                return new MySqlBridge(_connection as MySqlConnection, Program.LoggerFactory);
             }
 
             return null;
@@ -130,11 +130,11 @@ namespace Korzh.DbTool
             FileAttributes attr = File.GetAttributes(_arguments.InputPath);
             if ((attr & FileAttributes.Directory) == FileAttributes.Directory) {
 
-                return new FileFolderPacker(_arguments.InputPath);
+                return new FileFolderPacker(_arguments.InputPath, Program.LoggerFactory);
             }
 
             if (IsValidZipFile(_arguments.InputPath))
-                return new ZipFilePacker(_arguments.InputPath);
+                return new ZipFilePacker(_arguments.InputPath, Program.LoggerFactory);
 
             throw new Exception("Zip is not valid.");
         }
@@ -198,7 +198,7 @@ namespace Korzh.DbTool
             var dsImported = GetDatasetImporter();
 
             Console.WriteLine($"Importing data to [{_arguments.ConnectionId}]...");
-            new DbImporter(dbSeeder, dsImported, unpacker).Import();
+            new DbImporter(dbSeeder, dsImported, unpacker, Program.LoggerFactory).Import();
             Console.WriteLine("Import completed!");
 
             return 0;

--- a/src/Korzh.DbTool/Commands/ImportCommand.cs
+++ b/src/Korzh.DbTool/Commands/ImportCommand.cs
@@ -58,8 +58,8 @@ namespace Korzh.DbTool
 
             var arguments = new ArgumentsAndOptions(command);
 
-            command.OnExecute(new ImportCommand(arguments, options).Run);
-
+            Func<int> runCommandFunc = new ImportCommand(arguments, options).Run;
+            command.OnExecute(runCommandFunc);
         }
 
         private readonly ArgumentsAndOptions _arguments;

--- a/src/Korzh.DbTool/Korzh.DbTool.csproj
+++ b/src/Korzh.DbTool/Korzh.DbTool.csproj
@@ -22,6 +22,7 @@ To add other types of connections please create an issue on GitHub repository.
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dbtool</ToolCommandName>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Korzh.DbTool/Korzh.DbTool.csproj
+++ b/src/Korzh.DbTool/Korzh.DbTool.csproj
@@ -22,7 +22,7 @@ To add other types of connections please create an issue on GitHub repository.
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dbtool</ToolCommandName>
-    <LangVersion>latestmajor</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Korzh.DbTool/Program.cs
+++ b/src/Korzh.DbTool/Program.cs
@@ -13,6 +13,14 @@ namespace Korzh.DbTool
 {
     class Program
     {
+
+        public static ILoggerFactory LoggerFactory;
+
+        static Program()
+        {
+            LoggerFactory = GetLoggerFactory();
+        }
+
         public static int Main(string[] args)
         {
             var app = new CommandLineApplication();

--- a/src/Korzh.DbTool/Program.cs
+++ b/src/Korzh.DbTool/Program.cs
@@ -56,7 +56,7 @@ namespace Korzh.DbTool
             options.FormatOption = app.Option("--format|-f",
                                               "Exporting/importing format (xml | json)",
                                               CommandOptionType.SingleValue)
-                                      .Accepts(config => config.Values(ignoreCase: true, "xml", "json"));
+                                      .Accepts(config => config.Values(true, "xml", "json"));
 
 
             // Register commands

--- a/src/Korzh.DbTool/Program.cs
+++ b/src/Korzh.DbTool/Program.cs
@@ -64,7 +64,8 @@ namespace Korzh.DbTool
             app.Command("import", c => ImportCommand.Configure(c, options));
             app.Command("connections", c => ConnectionsCommand.Configure(c, options));
 
-            app.OnExecute(new RootCommand(app, options).Run);
+            Func<int> runCommandFunc = new RootCommand(app, options).Run;
+            app.OnExecute(runCommandFunc);
         }
 
         private readonly CommandLineApplication _app;

--- a/src/Korzh.DbUtils.MySql/Korzh.DbUtils.MySql.xml
+++ b/src/Korzh.DbUtils.MySql/Korzh.DbUtils.MySql.xml
@@ -44,6 +44,14 @@
             <param name="connectionString">The connection string.</param>
             <returns>DbConnection.</returns>
         </member>
+        <member name="M:Korzh.DbUtils.MySql.MySqlBridge.ExtractColumnsList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
+            <summary>
+            Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
+            </summary>
+            <param name="tableSchema">The table schema.</param>
+            <param name="tableName">The table name.</param>
+            <param name="columns">The columns list.</param>
+        </member>
         <member name="M:Korzh.DbUtils.MySql.MySqlBridge.ExtractDatasetList(System.Collections.Generic.IList{Korzh.DbUtils.DatasetInfo})">
             <summary>
             Extracts the list of tables for the current DB and saves them to datasets list passed in the parameter.

--- a/src/Korzh.DbUtils.MySql/Korzh.DbUtils.MySql.xml
+++ b/src/Korzh.DbUtils.MySql/Korzh.DbUtils.MySql.xml
@@ -44,7 +44,7 @@
             <param name="connectionString">The connection string.</param>
             <returns>DbConnection.</returns>
         </member>
-        <member name="M:Korzh.DbUtils.MySql.MySqlBridge.ExtractColumnsList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
+        <member name="M:Korzh.DbUtils.MySql.MySqlBridge.ExtractColumnList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
             <summary>
             Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
             </summary>

--- a/src/Korzh.DbUtils.MySql/MySqlBridge.cs
+++ b/src/Korzh.DbUtils.MySql/MySqlBridge.cs
@@ -63,6 +63,64 @@ namespace Korzh.DbUtils.MySql
             return new MySqlConnection(connectionString);
         }
 
+
+        /// <summary>
+        /// Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
+        /// </summary>
+        /// <param name="tableSchema">The table schema.</param>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="columns">The columns list.</param>
+        protected override void ExtractColumnsList(string tableSchema, string tableName, IList<ColumnInfo> columns)
+        {
+            string[] restrictions = new string[3];
+            restrictions[2] = tableName;
+
+            DataTable schemaTable = Connection.GetSchema("Columns", restrictions);
+            foreach (DataRow row in schemaTable.Rows) {
+                var columnName = (string)row["column_name"];
+                var type = (string)row["data_type"];
+                ColumnInfo column = new ColumnInfo(columnName, SQLTypeToCLRType(type));
+                columns.Add(column);
+            }
+        }
+
+        private Type SQLTypeToCLRType(string type)
+        {
+            switch (type)
+            {
+                case "tinyint":
+                case "smallint":
+                    return typeof(short);
+                case "int":
+                    return typeof(int);
+                case "bigint":
+                case "mediumint":
+                case "set":
+                    return typeof(long);
+                case "float":
+                    return typeof(float);
+                case "double":
+                case "real":
+                    return typeof(double);
+                case "decimal":
+                case "numeric":
+                    return typeof(decimal);
+                case "tinyblob":
+                case "blob":
+                case "mediumblob":
+                case "longblob":
+                    return typeof(byte[]);
+                case "date":
+                case "datetime":
+                    return typeof(DateTime);
+                case "time":
+                case "timestamp":
+                    return typeof(TimeSpan);
+                default:
+                    return typeof(string);
+            }
+        }
+
         /// <summary>
         /// Extracts the list of tables for the current DB and saves them to datasets list passed in the parameter.
         /// </summary>

--- a/src/Korzh.DbUtils.MySql/MySqlBridge.cs
+++ b/src/Korzh.DbUtils.MySql/MySqlBridge.cs
@@ -70,7 +70,7 @@ namespace Korzh.DbUtils.MySql
         /// <param name="tableSchema">The table schema.</param>
         /// <param name="tableName">The table name.</param>
         /// <param name="columns">The columns list.</param>
-        protected override void ExtractColumnsList(string tableSchema, string tableName, IList<ColumnInfo> columns)
+        protected override void ExtractColumnList(string tableSchema, string tableName, IList<ColumnInfo> columns)
         {
             string[] restrictions = new string[3];
             restrictions[2] = tableName;

--- a/src/Korzh.DbUtils.SqlServer/Korzh.DbUtils.SqlServer.xml
+++ b/src/Korzh.DbUtils.SqlServer/Korzh.DbUtils.SqlServer.xml
@@ -45,7 +45,7 @@
             <param name="connectionString">The connection string.</param>
             <returns>DbConnection.</returns>
         </member>
-        <member name="M:Korzh.DbUtils.SqlServer.SqlServerBridge.ExtractColumnsList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
+        <member name="M:Korzh.DbUtils.SqlServer.SqlServerBridge.ExtractColumnList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
             <summary>
             Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
             </summary>

--- a/src/Korzh.DbUtils.SqlServer/Korzh.DbUtils.SqlServer.xml
+++ b/src/Korzh.DbUtils.SqlServer/Korzh.DbUtils.SqlServer.xml
@@ -45,6 +45,14 @@
             <param name="connectionString">The connection string.</param>
             <returns>DbConnection.</returns>
         </member>
+        <member name="M:Korzh.DbUtils.SqlServer.SqlServerBridge.ExtractColumnsList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
+            <summary>
+            Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
+            </summary>
+            <param name="tableSchema">The table schema.</param>
+            <param name="tableName">The table name.</param>
+            <param name="columns">The columns list.</param>
+        </member>
         <member name="M:Korzh.DbUtils.SqlServer.SqlServerBridge.ExtractDatasetList(System.Collections.Generic.IList{Korzh.DbUtils.DatasetInfo})">
             <summary>
             Gets the list of tables for the current DB and saves them to datasets list passed in the parameter.

--- a/src/Korzh.DbUtils.SqlServer/SqlServerBridge.cs
+++ b/src/Korzh.DbUtils.SqlServer/SqlServerBridge.cs
@@ -69,7 +69,7 @@ namespace Korzh.DbUtils.SqlServer
         /// <param name="tableSchema">The table schema.</param>
         /// <param name="tableName">The table name.</param>
         /// <param name="columns">The columns list.</param>
-        protected override void ExtractColumnsList(string tableSchema, string tableName, IList<ColumnInfo> columns)
+        protected override void ExtractColumnList(string tableSchema, string tableName, IList<ColumnInfo> columns)
         {
             string[] restrictions = new string[4];
             restrictions[2] = tableName;

--- a/src/Korzh.DbUtils.SqlServer/SqlServerBridge.cs
+++ b/src/Korzh.DbUtils.SqlServer/SqlServerBridge.cs
@@ -64,6 +64,64 @@ namespace Korzh.DbUtils.SqlServer
         }
 
         /// <summary>
+        /// Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
+        /// </summary>
+        /// <param name="tableSchema">The table schema.</param>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="columns">The columns list.</param>
+        protected override void ExtractColumnsList(string tableSchema, string tableName, IList<ColumnInfo> columns)
+        {
+            string[] restrictions = new string[4];
+            restrictions[2] = tableName;
+
+            DataTable schemaTable = Connection.GetSchema(SqlClientMetaDataCollectionNames.Columns, restrictions);
+            foreach (DataRow row in schemaTable.Rows) {
+                var columnName = (string)row["COLUMN_NAME"];
+                var type = (string)row["DATA_TYPE"];
+                if (type != "rowversion") { //ignore rowversion column as autoupdated by db
+                    ColumnInfo column = new ColumnInfo(columnName, SQLTypeToCLRType(type));
+                    columns.Add(column);
+                }  
+            }
+        }
+
+        private Type SQLTypeToCLRType(string type)
+        {
+            switch(type) {
+                case "bigint":
+                    return typeof(long);
+                case "numeric":
+                    return typeof(float);
+                case "bit":
+                    return typeof(bool);
+                case "smallint":
+                    return typeof(short);
+                case "smallmoney":
+                case "money":
+                case "decimal":
+                    return typeof(decimal);
+                case "float":
+                    return typeof(float);
+                case "real":
+                    return typeof(double);
+                case "smalldatetime":
+                case "datetime":
+                    return typeof(DateTime);
+                case "datetime2":
+                case "datetimeoffset":
+                    return typeof(DateTimeOffset);
+                case "time":
+                case "timestamp":
+                    return typeof(TimeSpan);
+                case "binary":
+                case "varbinary":
+                    return typeof(byte[]);
+                default:
+                    return typeof(string);
+            }
+        }
+
+        /// <summary>
         /// Gets the list of tables for the current DB and saves them to datasets list passed in the parameter.
         /// </summary>
         /// <param name="datasets">The list of datasets (tables) to fill.</param>

--- a/src/Korzh.DbUtils/DbBridge/BaseDbBridge.cs
+++ b/src/Korzh.DbUtils/DbBridge/BaseDbBridge.cs
@@ -142,7 +142,7 @@ namespace Korzh.DbUtils
             CheckConnection();
 
             var columns = new List<ColumnInfo>();
-            ExtractColumnsList(table.Schema, table.Name, columns);
+            ExtractColumnList(table.Schema, table.Name, columns);
 
             var sql = new StringBuilder();
             sql.Append("SELECT");
@@ -164,7 +164,7 @@ namespace Korzh.DbUtils
         /// <param name="tableSchema">The table schema.</param>
         /// <param name="tableName">The table name.</param>
         /// <param name="columns">The columns list.</param>
-        protected abstract void ExtractColumnsList(string tableSchema, string tableName, IList<ColumnInfo> columns);
+        protected abstract void ExtractColumnList(string tableSchema, string tableName, IList<ColumnInfo> columns);
 
 
         /// <summary>

--- a/src/Korzh.DbUtils/DbBridge/BaseDbBridge.cs
+++ b/src/Korzh.DbUtils/DbBridge/BaseDbBridge.cs
@@ -139,8 +139,33 @@ namespace Korzh.DbUtils
         /// <returns>IDataReader.</returns>
         public IDataReader GetDataReaderForTable(DatasetInfo table)
         {
-            return GetDataReaderForSql("SELECT * FROM " + GetTableFullName(table));
+            CheckConnection();
+
+            var columns = new List<ColumnInfo>();
+            ExtractColumnsList(table.Schema, table.Name, columns);
+
+            var sql = new StringBuilder();
+            sql.Append("SELECT");
+
+            foreach (var column in columns) {
+                sql.AppendFormat(" {0}{1}{2},", Quote1, column.Name, Quote2);
+            }
+
+            sql.Remove(sql.Length - 1, 1);
+            sql.AppendFormat(" FROM {0}", GetTableFullName(table));
+
+            return GetDataReaderForSql(sql.ToString());
         }
+
+
+        /// <summary>
+        /// Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
+        /// </summary>
+        /// <param name="tableSchema">The table schema.</param>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="columns">The columns list.</param>
+        protected abstract void ExtractColumnsList(string tableSchema, string tableName, IList<ColumnInfo> columns);
+
 
         /// <summary>
         /// Gets the list of tables (or other kind of dataset) for the current connection.

--- a/src/Korzh.DbUtils/Korzh.DbUtils.xml
+++ b/src/Korzh.DbUtils/Korzh.DbUtils.xml
@@ -404,6 +404,14 @@
             <param name="table">The table represented by <see cref="T:Korzh.DbUtils.DatasetInfo" /> structure.</param>
             <returns>IDataReader.</returns>
         </member>
+        <member name="M:Korzh.DbUtils.BaseDbBridge.ExtractColumnsList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
+            <summary>
+            Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
+            </summary>
+            <param name="tableSchema">The table schema.</param>
+            <param name="tableName">The table name.</param>
+            <param name="columns">The columns list.</param>
+        </member>
         <member name="M:Korzh.DbUtils.BaseDbBridge.GetDatasets">
             <summary>
             Gets the list of tables (or other kind of dataset) for the current connection.
@@ -588,12 +596,12 @@
             <seealso cref="T:Korzh.DbUtils.IDataPacker" />
             <seealso cref="T:Korzh.DbUtils.IDataUnpacker" />
         </member>
-        <member name="M:Korzh.DbUtils.Packing.ZipFilePacker.#ctor(System.String,Microsoft.Extensions.Logging.ILogger)">
+        <member name="M:Korzh.DbUtils.Packing.ZipFilePacker.#ctor(System.String,Microsoft.Extensions.Logging.ILoggerFactory)">
             <summary>
             Initializes a new instance of the <see cref="T:Korzh.DbUtils.Packing.ZipFilePacker"/> class.
             </summary>
             <param name="filePath">The path to the ZIP file.</param>
-            <param name="logger">The logger.</param>
+            <param name="loggerFactory">The logger factory.</param>
         </member>
         <member name="M:Korzh.DbUtils.Packing.ZipFilePacker.StartPacking(System.String)">
             <summary>

--- a/src/Korzh.DbUtils/Korzh.DbUtils.xml
+++ b/src/Korzh.DbUtils/Korzh.DbUtils.xml
@@ -404,7 +404,7 @@
             <param name="table">The table represented by <see cref="T:Korzh.DbUtils.DatasetInfo" /> structure.</param>
             <returns>IDataReader.</returns>
         </member>
-        <member name="M:Korzh.DbUtils.BaseDbBridge.ExtractColumnsList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
+        <member name="M:Korzh.DbUtils.BaseDbBridge.ExtractColumnList(System.String,System.String,System.Collections.Generic.IList{Korzh.DbUtils.ColumnInfo})">
             <summary>
             Extracts the list of columns for the current table and saves them to columns list passed in the parameter.
             </summary>

--- a/src/Korzh.DbUtils/Packing/ZipFilePacker.cs
+++ b/src/Korzh.DbUtils/Packing/ZipFilePacker.cs
@@ -24,8 +24,8 @@ namespace Korzh.DbUtils.Packing
         /// Initializes a new instance of the <see cref="ZipFilePacker"/> class.
         /// </summary>
         /// <param name="filePath">The path to the ZIP file.</param>
-        /// <param name="logger">The logger.</param>
-        public ZipFilePacker(string filePath, ILogger logger = null)
+        /// <param name="loggerFactory">The logger factory.</param>
+        public ZipFilePacker(string filePath, ILoggerFactory loggerFactory = null)
         {
             _filePath = filePath;
 
@@ -33,7 +33,7 @@ namespace Korzh.DbUtils.Packing
                 _filePath += ".zip";
             }
 
-            _logger = logger;
+            _logger = loggerFactory?.CreateLogger("Korzh.DbUtils");
         }
 
         /// <summary>


### PR DESCRIPTION
1. Fix problem with `ROWVERSION` (ignore during export)
2. Add `ExtractColumnsList` function and use it in `GetDataReaderForTable` to build select sql statement